### PR TITLE
[Debug] sys.argv[0]が存在しない場合の条件処理を差し替えと、190行目のpathがPathでない問題を特定する

### DIFF
--- a/for_github/workflows/convert_webp.py
+++ b/for_github/workflows/convert_webp.py
@@ -187,6 +187,7 @@ def __create_image(path, origin, to, icon):
             tag = f"_{tag}"
 
         # jpegを変換する際に必要。pngに影響がないのでそのまま採用する
+        print(path, type(path))
         image.convert('RGB').save(path.with_stem(f"{path.stem}{tag}"),
                                   None, quality=95, optimize=True)
 
@@ -273,7 +274,7 @@ def __main(path):
 if __name__ == "__main__":
     # 引数処理
     # `curl | python`で実施した場合、else時はカレントディレクトリを返す
-    filename = sys.argv[0] if len(sys.argv) > 0 else "curl script"
+    filename = "curl script" if sys.argv == "" else sys.argv[0]
     # 引数があればそれを、なければこのファイルと同じディレクトリを走査
     path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).cwd()
 


### PR DESCRIPTION
必ずlen(sys.argv) > 0を満たす。要素の中に何も入っていない空文字（空要素では無い）が存在しているため、lenでは正しい判定ができなかった事に起因する